### PR TITLE
Public agenter er gjort litt mer klare for lansering

### DIFF
--- a/src/lib/server/db/mock-db.ts
+++ b/src/lib/server/db/mock-db.ts
@@ -6,13 +6,13 @@ import { APP_CONFIG } from "../app-config/app-config"
 
 const mockChatConfigs: ChatConfig[] = [
 	{
-		_id: "1234",
-		name: "Snille Mistral",
-		description: "En snill Mistral",
+		_id: "1000",
+		name: "Mistral",
+		description: "Mistral er en kraftig europeisk variant av ChatGPT",
 		vendorId: "MISTRAL",
 		project: "DEFAULT",
-		model: "mistral-medium-latest",
-		instructions: "Answer in Norwegian. Be overly polite and friendly.",
+		model: "mistral-large-latest",
+		instructions: "",
 		accessGroups: "all",
 		type: "published",
 		created: {
@@ -29,13 +29,36 @@ const mockChatConfigs: ChatConfig[] = [
 		}
 	},
 	{
-		_id: "5678",
-		name: "Sure OpenAI",
-		description: "En sur OpenAI",
+		_id: "2000",
+		name: "ChatGPT rask",
+		description: "OpenAIs KI for rask og presis informasjon.",
 		vendorId: "OPENAI",
 		project: "DEFAULT",
-		model: "gpt-4o",
-		instructions: "Answer in Norwegian. Be very grumpy and sarcastic.",
+		model: "gpt-4.1",
+		instructions: "",
+		accessGroups: "all",
+		type: "published",
+		created: {
+			at: new Date().toISOString(),
+			by: {
+				id: "system"
+			}
+		},
+		updated: {
+			at: new Date().toISOString(),
+			by: {
+				id: "system"
+			}
+		}
+	},
+		{
+		_id: "3000",
+		name: "ChatGPT tenker",
+		description: "OpenAIs avanserte og nyeste KI for rask tenkning og resonnering.",
+		vendorId: "OPENAI",
+		project: "DEFAULT",
+		model: "gpt-5.2",
+		instructions: "",
 		accessGroups: "all",
 		type: "published",
 		created: {


### PR DESCRIPTION
Fjernet systemledetekster og oppgraderte navn og beskrivelser på agentene.

Public agenter er nå:

- Mistral (mistral-large-latest)
- GPT-5.2
- GPT-4.1