### PR TITLE
Fire-and-forget transcription upload to avoid 504 gateway timeouts

### DIFF
--- a/src/lib/server/transcription/transcription.ts
+++ b/src/lib/server/transcription/transcription.ts
@@ -50,10 +50,6 @@ async function sendWithAxios(datapakken: FormData, token: string): Promise<Respo
 }
 
 export async function sendFileToTranscription(userUpn: string, filliste: Blob, metadata: TranscriptionMetadata): Promise<{ responseCode: number; message: string }> {
-	/*
-		const decoded = jwtDecode(bearerToken)
-		const user_upn = (decoded as any).upn	
-	*/
 	try {
 		const datapakken = new FormData()
 		datapakken.append("filer", filliste)
@@ -64,9 +60,13 @@ export async function sendFileToTranscription(userUpn: string, filliste: Blob, m
 
 		const token = env.TRANSCRIPTION_MOCK_TOKEN ? env.TRANSCRIPTION_MOCK_TOKEN : await getToken()
 
-		//const response = await _sendWithFetch(datapakken, token)
-		const response = await sendWithAxios(datapakken, token)
-		return { responseCode: response.status, message: response.statusText }
+		// Fire and forget — the downstream server polls Azure Blob for new files,
+		// so we don't need to wait for the transcription to complete.
+		sendWithAxios(datapakken, token).catch((error) => {
+			console.error("Failed to upload file for transcription:", error.message)
+		})
+
+		return { responseCode: 202, message: "File sent for transcription" }
 	} catch (error) {
 		return { responseCode: 500, message: (error as Error).message || "Internal server error" }
 	}

--- a/src/routes/api/transcription/+server.ts
+++ b/src/routes/api/transcription/+server.ts
@@ -17,13 +17,13 @@ const postTranscription: ApiNextFunction = async ({ requestEvent, user }) => {
 	const metadata: TranscriptionMetadata = JSON.parse(formData) // as unknown as TranscriptionMetadata
 	const response = await sendFileToTranscription(user.preferredUserName, fileList, metadata)
 
-	if (response.responseCode !== 200) {
+	if (response.responseCode >= 400) {
 		throw new HTTPError(response.responseCode, response.message)
 	}
 
 	return {
 		isAuthorized: true,
-		response: json(response)
+		response: json(response, { status: response.responseCode })
 	}
 }
 


### PR DESCRIPTION
The transcription endpoint now returns 202 immediately after initiating the upload, instead of waiting for the full transcription to complete. The downstream server polls Azure Blob independently, so awaiting the response is unnecessary.

Denne fixer 504 Gateway-timeout når man laster opp store filer til blob.