### PR TITLE
patch: 0.2.6 - agent-to-assistant

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "hugin-beta",
-	"version": "0.2.0",
+	"version": "0.2.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "hugin-beta",
-			"version": "0.2.0",
+			"version": "0.2.6",
 			"dependencies": {
 				"@mistralai/mistralai": "^2.2.0",
 				"@vestfoldfylke/loglady": "^1.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "hugin-beta",
-	"version": "0.2.0",
+	"version": "0.2.6",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/src/lib/components/AgentCard.svelte
+++ b/src/lib/components/AgentCard.svelte
@@ -32,11 +32,11 @@
 		<div class="agent-card-header">
 			<h2 class="agent-name">{agent.name || "Uten navn"}</h2>
 			{#if agent.type === "published"}
-				<span class="badge published" title="Publisert agent">
+				<span class="badge published" title="Publisert assistent">
 					<span class="material-symbols-outlined">public</span>
 				</span>
 			{:else}
-				<span class="badge private" title="Privat agent">
+				<span class="badge private" title="Privat assistent">
 					<span class="material-symbols-outlined">lock</span>
 				</span>
 			{/if}
@@ -45,7 +45,7 @@
 		{#if agent.description}
 			<p class="agent-description">{agent.description}</p>
 		{:else}
-			<p class="agent-description empty">Ingen beskrivelse</p>
+			<p class="agent-description empty">Ingen beskrivelse tilgjengelig for denne assistenten.</p>
 		{/if}
 
 		<div class="agent-meta">

--- a/src/lib/components/Chat/Chat.svelte
+++ b/src/lib/components/Chat/Chat.svelte
@@ -18,7 +18,7 @@
 	beforeNavigate(({ cancel, from, to, type }) => {
 		// goto is for programmatic navigation (for now at least), we only care about user navigation
 		if (type !== "goto" && chatState.configEdited && from?.url.pathname !== to?.url.pathname) {
-			const confirmLeave = confirm("Du har ulagrede endringer i agent-konfigurasjonen. Er du sikker på at du vil forlate siden?")
+			const confirmLeave = confirm("Du har ulagrede endringer i assistent-konfigurasjonen. Er du sikker på at du vil forlate siden?")
 			if (!confirmLeave) {
 				cancel()
 			}

--- a/src/lib/components/Chat/ChatConfigPanel.svelte
+++ b/src/lib/components/Chat/ChatConfigPanel.svelte
@@ -45,7 +45,7 @@
 	const copyAgentUrl = async () => {
 		await navigator.clipboard.writeText(page.url.href)
 		chatState.chat.config.shared = true
-		alert("Agentens adresse er kopiert til utklippstavlen og kan limes inn i en mail eller melding for å deles med andre.\n\nNB: Alle med lenken kan bruke agenten.")
+		alert("Assistentens adresse er kopiert til utklippstavlen og kan limes inn i en mail eller melding for å deles med andre.\n\nNB: Alle med lenken kan bruke assistenten.")
 	}
 
 	// Almost illegal effect, but we need to auto-select first available model when changing vendor in manual config
@@ -113,7 +113,7 @@
 						class="name-input"
 						id="agent-name"
 						rows="1"
-						placeholder="Gi agenten et navn"
+						placeholder="Gi assistenten et navn"
 						bind:value={chatState.chat.config.name}
 						onkeydown={(e) => { if (e.key === "Enter") e.preventDefault() }}
 					></textarea>
@@ -123,8 +123,8 @@
 			<!-- Description -->
 			<div class="config-section">
 				<div class="config-item">
-					<label for="description">Beskrivelse av agent</label>
-					<GrowingTextArea id="description" style="textarea" initialRows={1} placeholder="Skriv en beskrivelse av agenten her" bind:value={chatState.chat.config.description} />
+					<label for="description">Beskrivelse av assistent</label>
+					<GrowingTextArea id="description" style="textarea" initialRows={1} placeholder="Skriv en beskrivelse av assistenten her" bind:value={chatState.chat.config.description} />
 				</div>
 			</div>
 
@@ -132,7 +132,7 @@
 			<div class="config-section">
 				<div class="share-row">
 					<label class="toggle-label">
-						<span>Del agent</span>
+						<span>Del assistent</span>
 						<span class="toggle">
 							<input type="checkbox" bind:checked={chatState.chat.config.shared} />
 							<span class="toggle-track"></span>
@@ -143,7 +143,7 @@
 					</button>
 				</div>
 				<div class="share-description">
-					Ved å dele din agent kan de som har lenken bruke den, men den blir ikke listet opp noe sted.
+					Ved å dele din assistent kan de som har lenken bruke den, men den blir ikke listet opp noe sted.
 				</div>
 			</div>
 
@@ -233,7 +233,7 @@
 			{#if chatState.chat.config.vendorAgent}
 				<div class="config-section">
 					<div class="config-item">
-						<label for="vendorAgentId">Agent-id</label>
+						<label for="vendorAgentId">Assistent-id</label>
 						<input id="vendorAgentId" placeholder="agent/prompt-id" type="text" bind:value={chatState.chat.config.vendorAgent.id} />
 					</div>
 				</div>
@@ -244,7 +244,7 @@
 		<div class="config-actions">
 			<div class="config-action-item">
 				{#if chatState.chat.config._id}
-					<button class="filled danger" onclick={chatState.deleteChatConfig}><span class="material-symbols-outlined">delete</span>Slett agent</button>
+					<button class="filled danger" onclick={chatState.deleteChatConfig}><span class="material-symbols-outlined">delete</span>Slett assistent</button>
 				{:else}
 					&nbsp;
 				{/if}
@@ -253,14 +253,14 @@
 				{#if chatState.configEdited}
 					<button onclick={() => chatState.configMode = false} title="Test endringer i samtalen">
 						<span class="material-symbols-rounded">experiment</span>
-						Test agent
+						Test assistent
 					</button>
 				{/if}
 				<button onclick={() => { chatState.chat.config = JSON.parse(JSON.stringify(chatState.initialConfig)); chatState.configMode = false; }}>Avbryt</button>
 				{#if chatState.chat.config._id}
 					<button disabled={!chatState.configEdited} class="filled" onclick={chatState.updateChatConfig}><span class="material-symbols-outlined">save</span>Lagre endringer</button>
 				{:else}
-					<button disabled={!chatState.configEdited} class="filled" onclick={chatState.saveChatConfig}><span class="material-symbols-outlined">save</span>Lagre som ny agent</button>
+					<button disabled={!chatState.configEdited} class="filled" onclick={chatState.saveChatConfig}><span class="material-symbols-outlined">save</span>Lagre som ny assistent</button>
 				{/if}
 			</div>
 		</div>

--- a/src/lib/components/Chat/ChatHeaderWithConfig.svelte
+++ b/src/lib/components/Chat/ChatHeaderWithConfig.svelte
@@ -33,7 +33,7 @@
 		}
 		let name = chatState.chat.config.name || chatState.chat.config.model
 		if (!name) {
-			name = chatState.chat.config._id ? "Uten navn" : "Ny agent"
+			name = chatState.chat.config._id ? "Uten navn" : "Ny assistent"
 		}
 		if (chatState.configEdited) {
 			name += "*"
@@ -66,7 +66,7 @@
 					<ConversationExport bind:chat={chatState.chat} />
 				{/if}
 				{#if userCanEditConfig}
-					<button class="header-action" class:glow={chatState.configEdited} onclick={() => chatState.configMode = true} title="Konfigurer agent">
+					<button class="header-action" class:glow={chatState.configEdited} onclick={() => chatState.configMode = true} title="Konfigurer assistent">
 						<span class="material-symbols-rounded">build</span>
 						Konfigurer
 					</button>
@@ -86,7 +86,7 @@
 		{#if chatState.chat.config.description}
 			{chatState.chat.config.description}
 		{:else}
-			<em>Ingen beskrivelse tilgjengelig for denne agenten.</em>
+			<em>Ingen beskrivelse tilgjengelig for denne assistenten.</em>
 		{/if}
 	</div>
 {/if}

--- a/src/lib/components/Chat/ChatState.svelte.ts
+++ b/src/lib/components/Chat/ChatState.svelte.ts
@@ -348,7 +348,7 @@ export class ChatState {
 	}
 
 	public deleteChatConfig = async (): Promise<void> => {
-		const confirmDelete = confirm("Er du sikker på at du vil slette denne agenten? Dette kan ikke angres. 😬")
+		const confirmDelete = confirm("Er du sikker på at du vil slette denne assistenten? Dette kan ikke angres. 😬")
 		if (!confirmDelete) {
 			return
 		}

--- a/src/lib/components/Chat/PostChatMessage.svelte.ts
+++ b/src/lib/components/Chat/PostChatMessage.svelte.ts
@@ -3,7 +3,7 @@ import type { Chat, ChatRequest, ChatResponseObject } from "$lib/types/chat"
 import type { ChatOutputMessage } from "$lib/types/chat-item"
 
 export const addMessageDeltaToChatItem = (chatResponseObject: ChatResponseObject, itemId: string, messageDelta: string): ChatOutputMessage => {
-	if (!chatResponseObject || !chatResponseObject.outputs || !Array.isArray(chatResponseObject.outputs)) {
+	if (!chatResponseObject?.outputs || !Array.isArray(chatResponseObject.outputs)) {
 		throw new Error("No chatResponseObject.outputs to add message delta to")
 	}
 	if (!itemId) {

--- a/src/lib/components/Menu.svelte
+++ b/src/lib/components/Menu.svelte
@@ -129,25 +129,25 @@
 			<div class="menu-section">
 				{#if menuAgents.isLoading}
 					<div class="menu-section">
-						<div class="menu-section-title">Agenter</div>
+						<div class="menu-section-title">Assistenter</div>
 						loading...
 					</div>
 					<div class="menu-section">
-						<div class="menu-section-title">Dine agenter</div>
+						<div class="menu-section-title">Dine assistenter</div>
 						loading...
 					</div>
 				{:else if menuAgents.error}
 					<div class="menu-section">
-						<div class="menu-section-title">Agenter</div>
+						<div class="menu-section-title">Assistenter</div>
 						loading...
 					</div>
 					<div class="menu-section">
-						<div class="menu-section-title">Dine agenter</div>
+						<div class="menu-section-title">Dine assistenter</div>
 						loading...
 					</div>
 				{:else}
 					<div class="menu-section">
-						<div class="menu-section-title">Agenter</div>
+						<div class="menu-section-title">Assistenter</div>
 						<div class="menu-items">
 							{#each menuAgents.agents.filter(agent => agent.type === "published").slice(0,5) as agent}
 								<a class="menu-item" class:active={page.url.pathname === "/agents/" + agent._id} href={"/agents/" + agent._id}>
@@ -155,12 +155,12 @@
 								</a>
 							{/each}
 							<a class="menu-item" class:active={page.url.pathname === "/agents"} href="/agents">
-								<span class="material-symbols-outlined">more_horiz</span>Se alle agenter
+								<span class="material-symbols-outlined">more_horiz</span>Se alle assistenter
 							</a>
 						</div>
 					</div>
 					<div class="menu-section">
-						<div class="menu-section-title">Dine agenter</div>
+						<div class="menu-section-title">Dine assistenter</div>
 						<div class="menu-items">
 							{#each menuAgents.agents.filter(agent => agent.type === "private" && agent.created.by.id === authenticatedUser.userId).slice(0,5) as agent}
 								<a class="menu-item" class:active={page.url.pathname === "/agents/" + agent._id} href={"/agents/" + agent._id}>
@@ -168,7 +168,7 @@
 								</a>
 							{/each}
 							<a class="menu-item" class:active={page.url.pathname === "/agents/create"} href="/agents/create">
-								<span class="material-symbols-outlined">add</span>Lag ny agent
+								<span class="material-symbols-outlined">add</span>Lag ny assistent
 							</a>
 						</div>	
 					</div>

--- a/src/lib/streaming.ts
+++ b/src/lib/streaming.ts
@@ -48,10 +48,10 @@ export const parseSse = (chunk: string): MuginSse[] => {
 		if (keyValueLines.length !== 2) {
 			throw new Error("Invalid SSE format - must contain exactly two lines per event (event and data)")
 		}
-		if (!keyValueLines[0] || !keyValueLines[0].startsWith("event: ")) {
+		if (!keyValueLines[0]?.startsWith("event: ")) {
 			throw new Error(`Invalid line (does not start with event:) ${keyValueLines[0]}`)
 		}
-		if (!keyValueLines[1] || !keyValueLines[1].startsWith("data: ")) {
+		if (!keyValueLines[1]?.startsWith("data: ")) {
 			throw new Error(`Invalid line (does not start with data:) ${keyValueLines[1]}`)
 		}
 		const event = keyValueLines[0].slice(7).trim()

--- a/src/routes/agents/+page.svelte
+++ b/src/routes/agents/+page.svelte
@@ -9,11 +9,11 @@
 <div class="agents-page">
 	<header class="page-header">
 		<div>&nbsp;</div>
-		<h1>Agenter</h1>
+		<h1>Assistenter</h1>
 		<a href="/agents/create" class="new-agent-link">
 			<button class="filled">
 				<span class="material-symbols-outlined">add</span>
-				Ny agent
+				Ny assistent
 			</button>
 		</a>
 	</header>
@@ -21,8 +21,8 @@
 	{#if data.agents.length === 0}
 		<div class="empty-state">
 			<span class="material-symbols-outlined empty-icon">smart_toy</span>
-			<p>Ingen agenter funnet</p>
-			<a href="/agents/create">Opprett din første agent</a>
+			<p>Ingen assistenter funnet</p>
+			<a href="/agents/create">Opprett din første assistent</a>
 		</div>
 	{:else}
 		<h3>Publiserte</h3>

--- a/src/routes/agents/[agentId]/+page.server.ts
+++ b/src/routes/agents/[agentId]/+page.server.ts
@@ -20,7 +20,7 @@ const agentPageLoad: ServerLoadNextFunction<{ agent: ChatConfig }> = async ({ re
 	}
 
 	if (!canPromptConfig(user, APP_CONFIG, agent)) {
-		throw new HTTPError(403, "Du har ikke tilgang til denne agenten")
+		throw new HTTPError(403, "Du har ikke tilgang til denne assistenten")
 	}
 
 	return {

--- a/src/routes/api/transcription/+server.ts
+++ b/src/routes/api/transcription/+server.ts
@@ -100,7 +100,7 @@ const deleteJob: ApiNextFunction = async ({ requestEvent, user }) => {
 
 	// Same priority for docx: in-memory job result → client-provided value.
 	const effectiveDocxUrl = job?.result?.docx_url ?? docxUrl
-	if (effectiveDocxUrl && effectiveDocxUrl.startsWith(copypartyBase)) {
+	if (effectiveDocxUrl?.startsWith(copypartyBase)) {
 		await fetch(`${effectiveDocxUrl}?delete`, { method: "POST" }).catch(() => null)
 	}
 


### PR DESCRIPTION
### Patch commits:
- fix: renamed agent to assistent (only text visible to user) (3fc7e88)

### Maintenance commits:
- chore: lint:fix (7c662ca)

Får vi lov å rename agenter til assistenter?
