### PR TITLE
Fix på issue #188

### DIFF
--- a/src/lib/components/Chat/PostChatMessage.svelte.ts
+++ b/src/lib/components/Chat/PostChatMessage.svelte.ts
@@ -47,9 +47,19 @@ export const postChatMessage = async (chatRequest: ChatRequest, chatResponseObje
 		})
 		if (!response.ok) {
 			console.error(`Error posting chat message: ${response.statusText}`)
-			const errorData = await response.json()
+			if (response.status === 401) {
+				chatResponseObject.status = "failed"
+				window.location.href = "/"
+				return
+			}
+			if (response.status === 403) {
+				chatResponseObject.status = "failed"
+				window.location.href = "/"
+				return
+			}
+			const errorData = await response.json().catch(() => null)
 			console.error("Error details:", errorData)
-			throw new Error(`Error posting chat message: ${response.statusText}`) // For now, just throw an error
+			throw new Error(`Error posting chat message: ${response.statusText}`)
 		}
 		if (chatRequest.stream) {
 			if (!response.body) {
@@ -58,67 +68,61 @@ export const postChatMessage = async (chatRequest: ChatRequest, chatResponseObje
 			if (!response.body.getReader) {
 				throw new Error("Response body does not support streaming")
 			}
-			try {
-				const reader = response.body.getReader()
-				const decoder = new TextDecoder("utf-8")
-				while (true) {
-					const { value, done } = await reader.read()
-					const chatResponseText = decoder.decode(value, { stream: true })
-					const chatResponse = parseSse(chatResponseText)
-					for (const chatResult of chatResponse) {
-						switch (chatResult.event) {
-							case "conversation.created": {
-								console.log("Conversation created with ID:", chatResult.data.conversationId)
-								chat.config.conversationId = chatResult.data.conversationId // Trolig ikke greit i følge svelte... siden vi endrer state i en annet scope enn den som eier staten
-								break
+			const reader = response.body.getReader()
+			const decoder = new TextDecoder("utf-8")
+			while (true) {
+				const { value, done } = await reader.read()
+				const chatResponseText = decoder.decode(value, { stream: true })
+				const chatResponse = parseSse(chatResponseText)
+				for (const chatResult of chatResponse) {
+					switch (chatResult.event) {
+						case "conversation.created": {
+							console.log("Conversation created with ID:", chatResult.data.conversationId)
+							chat.config.conversationId = chatResult.data.conversationId // Trolig ikke greit i følge svelte... siden vi endrer state i en annet scope enn den som eier staten
+							break
+						}
+						case "response.started": {
+							const { responseId } = chatResult.data
+							console.log("Response started with ID:", chatResult.data.responseId)
+							chatResponseObject.id = responseId
+							chatResponseObject.status = "in_progress"
+							break
+						}
+						case "response.output_text.delta": {
+							addMessageDeltaToChatItem(chatResponseObject, chatResult.data.itemId, chatResult.data.content)
+							break
+						}
+						case "response.searching": {
+							chatResponseObject.status = "searching"
+							break
+						}
+						case "response.done": {
+							console.log("Response done. Total tokens used:", chatResult.data.usage.totalTokens)
+							chatResponseObject.status = "completed"
+							chatResponseObject.usage = chatResult.data.usage
+							break
+						}
+						case "response.annotations": {
+							const outputMessage = chatResponseObject.outputs.find((o) => o.type === "message.output" && o.id === chatResult.data.itemId)
+							if (outputMessage?.type === "message.output" && outputMessage.content[0]?.type === "output_text") {
+								const existing = outputMessage.content[0].annotations ?? []
+								outputMessage.content[0].annotations = [...existing, ...chatResult.data.annotations]
 							}
-							case "response.started": {
-								const { responseId } = chatResult.data
-								console.log("Response started with ID:", chatResult.data.responseId)
-								chatResponseObject.id = responseId
-								chatResponseObject.status = "in_progress"
-								break
-							}
-							case "response.output_text.delta": {
-								addMessageDeltaToChatItem(chatResponseObject, chatResult.data.itemId, chatResult.data.content)
-								break
-							}
-							case "response.searching": {
-								chatResponseObject.status = "searching"
-								break
-							}
-							case "response.done": {
-								console.log("Response done. Total tokens used:", chatResult.data.usage.totalTokens)
-								chatResponseObject.status = "completed"
-								chatResponseObject.usage = chatResult.data.usage
-								break
-							}
-							case "response.annotations": {
-								const outputMessage = chatResponseObject.outputs.find((o) => o.type === "message.output" && o.id === chatResult.data.itemId)
-								if (outputMessage?.type === "message.output" && outputMessage.content[0]?.type === "output_text") {
-									const existing = outputMessage.content[0].annotations ?? []
-									outputMessage.content[0].annotations = [...existing, ...chatResult.data.annotations]
-								}
-								break
-							}
-							case "response.error": {
-								console.error("Response error:", chatResult.data.code, chatResult.data.message)
-								addMessageDeltaToChatItem(chatResponseObject, `error_${Date.now()}`, `\n\n[Error: ${chatResult.data.message}]`)
-								chatResponseObject.status = "failed"
-								break
-							}
-							default: {
-								console.warn("Unhandled chat result event:", chatResult.event)
-								break
-							}
+							break
+						}
+						case "response.error": {
+							console.error("Response error:", chatResult.data.code, chatResult.data.message)
+							addMessageDeltaToChatItem(chatResponseObject, `error_${Date.now()}`, `\n\n[Error: ${chatResult.data.message}]`)
+							chatResponseObject.status = "failed"
+							break
+						}
+						default: {
+							console.warn("Unhandled chat result event:", chatResult.event)
+							break
 						}
 					}
-					if (done) break
 				}
-			} catch (error) {
-				addMessageDeltaToChatItem(chatResponseObject, `error_${Date.now()}`, "\n\n[Error occurred while receiving agent response]")
-				chatResponseObject.status = "failed"
-				throw error
+				if (done) break
 			}
 			return
 		}

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	import { page } from "$app/stores"
+</script>
+
+<div class="error-container">
+	{#if $page.status === 401}
+		<h1>Sesjonen din har utløpt</h1>
+		<p>Du må logge inn på nytt for å fortsette.</p>
+		<a href="/">Logg inn</a>
+	{:else if $page.status === 403}
+		<h1>Ingen tilgang</h1>
+		<p>Du har ikke tilgang til denne siden.</p>
+		<a href="/">Gå til forsiden</a>
+	{:else}
+		<h1>Noe gikk galt</h1>
+		<p>{$page.error?.message ?? "En ukjent feil oppstod."}</p>
+		<a href="/">Gå til forsiden</a>
+	{/if}
+</div>
+
+<style>
+	.error-container {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		height: 100%;
+		gap: 1rem;
+		text-align: center;
+		padding: 2rem;
+	}
+
+	h1 {
+		font-size: 1.5rem;
+		font-weight: 700;
+	}
+
+	a {
+		margin-top: 0.5rem;
+		padding: 0.5rem 1.5rem;
+		background-color: var(--color-primary, #0066cc);
+		color: white;
+		border-radius: 4px;
+		text-decoration: none;
+	}
+
+	a:hover {
+		opacity: 0.85;
+	}
+</style>


### PR DESCRIPTION
Fiks: Session som løper ut ( Issue: #188 )

Når en brukers sesjon utløp, ble ikke brukeren logget ut på riktig måte. I stedet fikk brukeren enten en feilmelding inline i chatten, eller en generisk "en feil oppstod"-side før eventuell viderekobling til innlogging.

Hva er fikset:

Klienten oppdager nå 401 og 403-svar fra API-et og videresender brukeren til forsiden (som EasyAuth fanger opp og sender videre til innlogging)
401 og 403 håndteres separat — utløpt sesjon vs. manglende tilgang er to forskjellige ting
Lagt til en egen feilside (+error.svelte) som viser en forståelig melding ved server-side autentiseringsfeil
Fjernet mulighet for at feilmeldinger ble skrevet dobbelt i chatten
response.json() ved feilhåndtering er gjort robust mot ikke-JSON-responser
Berørte filer:

src/lib/components/Chat/PostChatMessage.svelte.ts
src/routes/+error.svelte (ny fil)