### PR TITLE
Fix - respons som forsvinner

### DIFF
--- a/src/routes/agents/[agentId]/+page.svelte
+++ b/src/routes/agents/[agentId]/+page.svelte
@@ -21,11 +21,19 @@
 
 	const agentChatState = new ChatState(initialChat, data.authenticatedUser, data.APP_CONFIG)
 
-	// Get url param agentId and update chat config when it changes
+	// Track which agent the current chat belongs to, so we only reset on a real
+	// agentId change — not on every `data` update (e.g. invalidateAll() on tab
+	// refocus, which would otherwise wipe the in-progress conversation).
+	let loadedAgentId = $state(page.params.agentId)
+
+	// Reset the chat only when the url param agentId actually changes
 	$effect(() => {
-		console.log("Agent ID changed:", page.params.agentId)
-		page.params.agentId
-		const initialChat: Chat = {
+		const agentId = page.params.agentId
+		if (agentId === loadedAgentId) {
+			return
+		}
+		loadedAgentId = agentId
+		const newChat: Chat = {
 			_id: "",
 			createdAt: "",
 			updatedAt: "",
@@ -36,7 +44,7 @@
 			config: data.agent,
 			history: []
 		}
-		agentChatState.changeChat(initialChat)
+		agentChatState.changeChat(newChat)
 	})
 </script>
   <ChatComponent chatState={agentChatState} />


### PR DESCRIPTION
Når en bruker chattet med en agent og byttet til en annen fane/vindu og tilbake, ble samtalen (svaret) slettet.

Årsak
$effect-en på agent-siden ([+page.svelte](vscode-webview://04nakrtrbg6ehb7b9bq8njehptqiu6httdgqdksgs9vnkmrl3jj0/src/routes/agents/%5BagentId%5D/+page.svelte)) skulle kun tilbakestille chatten når agentId endret seg, men leste også data.agent reaktivt. Den kjørte derfor på hver data-endring. invalidateAll() ved fanefokus (lagt til i #195 for sesjonsrevalidering) genererer nytt data hver gang, noe som trigget changeChat({ history: [] }) og slettet samtalen.

Løsning
Latent feil siden #84 (effekten var for bredt reaktiv) La til en loadedAgentId-vakt slik at effekten kun tilbakestiller ved ekte endring av agentId. Fjernet en gammel console.log fra #84 Sesjonsrevalideringen fra #195 er uendret.

Testet
Reprodusert lokalt, og verifisert at samtalen nå består etter fanebytte.