### PR TITLE
Add Mermaid diagram tool to Kladdeboka

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2909,9 +2909,9 @@
 			}
 		},
 		"node_modules/katex": {
-			"version": "0.16.47",
-			"resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
-			"integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+			"version": "0.16.45",
+			"resolved": "https://registry.npmjs.org/katex/-/katex-0.16.45.tgz",
+			"integrity": "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==",
 			"funding": [
 				"https://opencollective.com/katex",
 				"https://github.com/sponsors/katex"
@@ -3075,6 +3075,22 @@
 				"stylis": "^4.3.6",
 				"ts-dedent": "^2.2.0",
 				"uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
+			}
+		},
+		"node_modules/mermaid/node_modules/katex": {
+			"version": "0.16.47",
+			"resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+			"integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+			"funding": [
+				"https://opencollective.com/katex",
+				"https://github.com/sponsors/katex"
+			],
+			"license": "MIT",
+			"dependencies": {
+				"commander": "^8.3.0"
+			},
+			"bin": {
+				"katex": "cli.js"
 			}
 		},
 		"node_modules/minimalistic-assert": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
 				"jwt-decode": "^4.0.0",
 				"katex": "^0.16.45",
 				"markdown-it": "^14.1.1",
+				"mermaid": "^11.17.0",
 				"mongodb": "^7.1.1",
 				"ollama": "^0.6.3",
 				"openai": "^6.34.0",
@@ -35,6 +36,19 @@
 				"typescript": "^5.9.3",
 				"vite": "^7.3.2",
 				"vitest": "^4.1.4"
+			}
+		},
+		"node_modules/@antfu/install-pkg": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+			"integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+			"license": "MIT",
+			"dependencies": {
+				"package-manager-detector": "^1.3.0",
+				"tinyexec": "^1.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
 			}
 		},
 		"node_modules/@biomejs/biome": {
@@ -199,6 +213,18 @@
 			"engines": {
 				"node": ">=14.21.3"
 			}
+		},
+		"node_modules/@braintree/sanitize-url": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+			"integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+			"license": "MIT"
+		},
+		"node_modules/@chevrotain/types": {
+			"version": "11.1.2",
+			"resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+			"integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+			"license": "Apache-2.0"
 		},
 		"node_modules/@esbuild/aix-ppc64": {
 			"version": "0.28.2",
@@ -642,6 +668,23 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@iconify/types": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+			"integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+			"license": "MIT"
+		},
+		"node_modules/@iconify/utils": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.4.tgz",
+			"integrity": "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==",
+			"license": "MIT",
+			"dependencies": {
+				"@antfu/install-pkg": "^1.1.0",
+				"@iconify/types": "^2.0.0",
+				"import-meta-resolve": "^4.2.0"
+			}
+		},
 		"node_modules/@jridgewell/gen-mapping": {
 			"version": "0.3.13",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -690,6 +733,15 @@
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
+		"node_modules/@mermaid-js/parser": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.1.tgz",
+			"integrity": "sha512-n12NohV3mrUyUL2o93IgG/ifeW9FTyeJn3zDxkhwa8MJ9Fxg3HQMlA3RiGmD/3UnJvheztkjjQAjA2T4LmUcpw==",
+			"license": "MIT",
+			"dependencies": {
+				"@chevrotain/types": "~11.1.2"
 			}
 		},
 		"node_modules/@mistralai/mistralai": {
@@ -1315,6 +1367,259 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/d3": {
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+			"integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-array": "*",
+				"@types/d3-axis": "*",
+				"@types/d3-brush": "*",
+				"@types/d3-chord": "*",
+				"@types/d3-color": "*",
+				"@types/d3-contour": "*",
+				"@types/d3-delaunay": "*",
+				"@types/d3-dispatch": "*",
+				"@types/d3-drag": "*",
+				"@types/d3-dsv": "*",
+				"@types/d3-ease": "*",
+				"@types/d3-fetch": "*",
+				"@types/d3-force": "*",
+				"@types/d3-format": "*",
+				"@types/d3-geo": "*",
+				"@types/d3-hierarchy": "*",
+				"@types/d3-interpolate": "*",
+				"@types/d3-path": "*",
+				"@types/d3-polygon": "*",
+				"@types/d3-quadtree": "*",
+				"@types/d3-random": "*",
+				"@types/d3-scale": "*",
+				"@types/d3-scale-chromatic": "*",
+				"@types/d3-selection": "*",
+				"@types/d3-shape": "*",
+				"@types/d3-time": "*",
+				"@types/d3-time-format": "*",
+				"@types/d3-timer": "*",
+				"@types/d3-transition": "*",
+				"@types/d3-zoom": "*"
+			}
+		},
+		"node_modules/@types/d3-array": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+			"integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-axis": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+			"integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-selection": "*"
+			}
+		},
+		"node_modules/@types/d3-brush": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+			"integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-selection": "*"
+			}
+		},
+		"node_modules/@types/d3-chord": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+			"integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-color": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+			"integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-contour": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+			"integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-array": "*",
+				"@types/geojson": "*"
+			}
+		},
+		"node_modules/@types/d3-delaunay": {
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+			"integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-dispatch": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+			"integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-drag": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+			"integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-selection": "*"
+			}
+		},
+		"node_modules/@types/d3-dsv": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+			"integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-ease": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+			"integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-fetch": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+			"integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-dsv": "*"
+			}
+		},
+		"node_modules/@types/d3-force": {
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+			"integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-format": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+			"integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-geo": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.1.tgz",
+			"integrity": "sha512-65Emv9fQiQQqphLlRkuQ5ypPsOmWPhtBGCMv61JDPEPMvsx+gzhGf74yw1a78xFKPj6zw4AgQICJoQv0vK9M2w==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/geojson": "*"
+			}
+		},
+		"node_modules/@types/d3-hierarchy": {
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+			"integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-interpolate": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+			"integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-color": "*"
+			}
+		},
+		"node_modules/@types/d3-path": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+			"integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-polygon": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+			"integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-quadtree": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+			"integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-random": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.4.tgz",
+			"integrity": "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-scale": {
+			"version": "4.0.9",
+			"resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+			"integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-time": "*"
+			}
+		},
+		"node_modules/@types/d3-scale-chromatic": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+			"integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-selection": {
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+			"integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-shape": {
+			"version": "3.1.8",
+			"resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+			"integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-path": "*"
+			}
+		},
+		"node_modules/@types/d3-time": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+			"integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-time-format": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+			"integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-timer": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+			"integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-transition": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+			"integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-selection": "*"
+			}
+		},
+		"node_modules/@types/d3-zoom": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+			"integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-interpolate": "*",
+				"@types/d3-selection": "*"
+			}
+		},
 		"node_modules/@types/deep-eql": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1327,6 +1632,12 @@
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
 			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/geojson": {
+			"version": "7946.0.16",
+			"resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+			"integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
 			"license": "MIT"
 		},
 		"node_modules/@types/linkify-it": {
@@ -1374,7 +1685,7 @@
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
 			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/webidl-conversions": {
@@ -1390,6 +1701,16 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/webidl-conversions": "*"
+			}
+		},
+		"node_modules/@upsetjs/venn.js": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+			"integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+			"license": "MIT",
+			"optionalDependencies": {
+				"d3-selection": "^3.0.0",
+				"d3-transition": "^3.0.1"
 			}
 		},
 		"node_modules/@vestfoldfylke/loglady": {
@@ -1676,6 +1997,529 @@
 			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
 			"license": "MIT"
 		},
+		"node_modules/cose-base": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+			"integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+			"license": "MIT",
+			"dependencies": {
+				"layout-base": "^1.0.0"
+			}
+		},
+		"node_modules/cytoscape": {
+			"version": "3.34.1",
+			"resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.1.tgz",
+			"integrity": "sha512-Lr0RvH9H75y9ar8h9Toy6u4lxRSCcxUq+hHcQ26sVWo6BnaQp1gwEZOYqwuYTZhyW7npyKnNLP8oJ2p1/3OZ7g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/cytoscape-cose-bilkent": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+			"integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+			"license": "MIT",
+			"dependencies": {
+				"cose-base": "^1.0.0"
+			},
+			"peerDependencies": {
+				"cytoscape": "^3.2.0"
+			}
+		},
+		"node_modules/cytoscape-fcose": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+			"integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+			"license": "MIT",
+			"dependencies": {
+				"cose-base": "^2.2.0"
+			},
+			"peerDependencies": {
+				"cytoscape": "^3.2.0"
+			}
+		},
+		"node_modules/cytoscape-fcose/node_modules/cose-base": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+			"integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+			"license": "MIT",
+			"dependencies": {
+				"layout-base": "^2.0.0"
+			}
+		},
+		"node_modules/cytoscape-fcose/node_modules/layout-base": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+			"integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+			"license": "MIT"
+		},
+		"node_modules/d3": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+			"integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-array": "3",
+				"d3-axis": "3",
+				"d3-brush": "3",
+				"d3-chord": "3",
+				"d3-color": "3",
+				"d3-contour": "4",
+				"d3-delaunay": "6",
+				"d3-dispatch": "3",
+				"d3-drag": "3",
+				"d3-dsv": "3",
+				"d3-ease": "3",
+				"d3-fetch": "3",
+				"d3-force": "3",
+				"d3-format": "3",
+				"d3-geo": "3",
+				"d3-hierarchy": "3",
+				"d3-interpolate": "3",
+				"d3-path": "3",
+				"d3-polygon": "3",
+				"d3-quadtree": "3",
+				"d3-random": "3",
+				"d3-scale": "4",
+				"d3-scale-chromatic": "3",
+				"d3-selection": "3",
+				"d3-shape": "3",
+				"d3-time": "3",
+				"d3-time-format": "4",
+				"d3-timer": "3",
+				"d3-transition": "3",
+				"d3-zoom": "3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-array": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+			"integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+			"license": "ISC",
+			"dependencies": {
+				"internmap": "1 - 2"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-axis": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+			"integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-brush": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+			"integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-dispatch": "1 - 3",
+				"d3-drag": "2 - 3",
+				"d3-interpolate": "1 - 3",
+				"d3-selection": "3",
+				"d3-transition": "3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-chord": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+			"integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-path": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-color": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+			"integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-contour": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+			"integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-array": "^3.2.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-delaunay": {
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+			"integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+			"license": "ISC",
+			"dependencies": {
+				"delaunator": "5"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-dispatch": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+			"integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-drag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+			"integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-dispatch": "1 - 3",
+				"d3-selection": "3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-dsv": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+			"integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+			"license": "ISC",
+			"dependencies": {
+				"commander": "7",
+				"iconv-lite": "0.6",
+				"rw": "1"
+			},
+			"bin": {
+				"csv2json": "bin/dsv2json.js",
+				"csv2tsv": "bin/dsv2dsv.js",
+				"dsv2dsv": "bin/dsv2dsv.js",
+				"dsv2json": "bin/dsv2json.js",
+				"json2csv": "bin/json2dsv.js",
+				"json2dsv": "bin/json2dsv.js",
+				"json2tsv": "bin/json2dsv.js",
+				"tsv2csv": "bin/dsv2dsv.js",
+				"tsv2json": "bin/dsv2json.js"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-dsv/node_modules/commander": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+			"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/d3-ease": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+			"integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-fetch": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+			"integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-dsv": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-force": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+			"integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-dispatch": "1 - 3",
+				"d3-quadtree": "1 - 3",
+				"d3-timer": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-format": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+			"integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-geo": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+			"integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-array": "2.5.0 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-hierarchy": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+			"integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-interpolate": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+			"integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-color": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-path": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+			"integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-polygon": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+			"integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-quadtree": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+			"integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-random": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+			"integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-sankey": {
+			"version": "0.12.3",
+			"resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+			"integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"d3-array": "1 - 2",
+				"d3-shape": "^1.2.0"
+			}
+		},
+		"node_modules/d3-sankey/node_modules/d3-array": {
+			"version": "2.12.1",
+			"resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+			"integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"internmap": "^1.0.0"
+			}
+		},
+		"node_modules/d3-sankey/node_modules/d3-path": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+			"integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/d3-sankey/node_modules/d3-shape": {
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+			"integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"d3-path": "1"
+			}
+		},
+		"node_modules/d3-sankey/node_modules/internmap": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+			"integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+			"license": "ISC"
+		},
+		"node_modules/d3-scale": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+			"integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-array": "2.10.0 - 3",
+				"d3-format": "1 - 3",
+				"d3-interpolate": "1.2.0 - 3",
+				"d3-time": "2.1.1 - 3",
+				"d3-time-format": "2 - 4"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-scale-chromatic": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+			"integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-color": "1 - 3",
+				"d3-interpolate": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-selection": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+			"integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-shape": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+			"integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-path": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-time": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+			"integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-array": "2 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-time-format": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+			"integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-time": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-timer": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+			"integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-transition": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+			"integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-color": "1 - 3",
+				"d3-dispatch": "1 - 3",
+				"d3-ease": "1 - 3",
+				"d3-interpolate": "1 - 3",
+				"d3-timer": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"d3-selection": "2 - 3"
+			}
+		},
+		"node_modules/d3-zoom": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+			"integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-dispatch": "1 - 3",
+				"d3-drag": "2 - 3",
+				"d3-interpolate": "1 - 3",
+				"d3-selection": "2 - 3",
+				"d3-transition": "2 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/dagre-d3-es": {
+			"version": "7.0.14",
+			"resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+			"integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+			"license": "MIT",
+			"dependencies": {
+				"d3": "^7.9.0",
+				"lodash-es": "^4.17.21"
+			}
+		},
+		"node_modules/dayjs": {
+			"version": "1.11.23",
+			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.23.tgz",
+			"integrity": "sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==",
+			"license": "MIT"
+		},
 		"node_modules/deepmerge": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -1684,6 +2528,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/delaunator": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+			"integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+			"license": "ISC",
+			"dependencies": {
+				"robust-predicates": "^3.0.2"
 			}
 		},
 		"node_modules/devalue": {
@@ -1728,6 +2581,15 @@
 				"node": "^18 || >=20"
 			}
 		},
+		"node_modules/dompurify": {
+			"version": "3.4.14",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+			"integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
+			"license": "(MPL-2.0 OR Apache-2.0)",
+			"optionalDependencies": {
+				"@types/trusted-types": "^2.0.7"
+			}
+		},
 		"node_modules/entities": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -1756,6 +2618,18 @@
 			"integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/es-toolkit": {
+			"version": "1.51.0",
+			"resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.51.0.tgz",
+			"integrity": "sha512-zC2lQGkM7QX+Gm6iM3+WIdZJzthsEd14LvRNJneSO2hzyz/zNBENR8+YXWo1cKxgPBtV6ksPYHELbcwBRzmdCw==",
+			"license": "MIT",
+			"workspaces": [
+				"docs",
+				"benchmarks",
+				"tests/types",
+				"tests/browser-compat"
+			]
 		},
 		"node_modules/esbuild": {
 			"version": "0.28.2",
@@ -1841,6 +2715,15 @@
 				"node": ">=12.0.0"
 			}
 		},
+		"node_modules/fastdom": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/fastdom/-/fastdom-1.0.12.tgz",
+			"integrity": "sha512-LB+xjSTEbjHE1cWsxu+tN2Xqr1kpi+V9aADI7sVM5ZMaXyYGPHULQMzpJMYqOTULK/73pUkWVzzObFRBkPr+hg==",
+			"license": "MIT",
+			"dependencies": {
+				"strictdom": "^1.0.1"
+			}
+		},
 		"node_modules/fdir": {
 			"version": "6.5.0",
 			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1884,6 +2767,12 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/hachure-fill": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+			"integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+			"license": "MIT"
+		},
 		"node_modules/hash.js": {
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
@@ -1916,17 +2805,48 @@
 				"node": ">=12.0.0"
 			}
 		},
+		"node_modules/iconv-lite": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/immediate": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
 			"integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
 			"license": "MIT"
 		},
+		"node_modules/import-meta-resolve": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+			"integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"license": "ISC"
+		},
+		"node_modules/internmap": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+			"integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
 		},
 		"node_modules/is-core-module": {
 			"version": "2.16.1",
@@ -1989,9 +2909,9 @@
 			}
 		},
 		"node_modules/katex": {
-			"version": "0.16.45",
-			"resolved": "https://registry.npmjs.org/katex/-/katex-0.16.45.tgz",
-			"integrity": "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==",
+			"version": "0.16.47",
+			"resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+			"integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
 			"funding": [
 				"https://opencollective.com/katex",
 				"https://github.com/sponsors/katex"
@@ -2004,6 +2924,11 @@
 				"katex": "cli.js"
 			}
 		},
+		"node_modules/khroma": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+			"integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
+		},
 		"node_modules/kleur": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -2013,6 +2938,12 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/layout-base": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+			"integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+			"license": "MIT"
 		},
 		"node_modules/lie": {
 			"version": "3.3.0",
@@ -2047,6 +2978,12 @@
 			"resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
 			"integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lodash-es": {
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+			"integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
 			"license": "MIT"
 		},
 		"node_modules/magic-string": {
@@ -2086,6 +3023,18 @@
 				"markdown-it": "bin/markdown-it.mjs"
 			}
 		},
+		"node_modules/marked": {
+			"version": "16.4.2",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+			"integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
 		"node_modules/mdurl": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
@@ -2097,6 +3046,36 @@
 			"resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
 			"integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
 			"license": "MIT"
+		},
+		"node_modules/mermaid": {
+			"version": "11.17.0",
+			"resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.17.0.tgz",
+			"integrity": "sha512-Jo9N377Wb4MSnHFPTbLi2SxFpsQl4eVHoxnW5U1Md9EazvgMp3s+4ohDxr81YNTgbn5Kj7HJ3yslrSJ52kwpbA==",
+			"license": "MIT",
+			"dependencies": {
+				"@braintree/sanitize-url": "^7.1.2",
+				"@iconify/utils": "^3.0.2",
+				"@mermaid-js/parser": "^1.2.1",
+				"@types/d3": "^7.4.3",
+				"@upsetjs/venn.js": "^2.0.0",
+				"cytoscape": "^3.34.0",
+				"cytoscape-cose-bilkent": "^4.1.0",
+				"cytoscape-fcose": "^2.2.0",
+				"d3": "^7.9.0",
+				"d3-sankey": "^0.12.3",
+				"dagre-d3-es": "7.0.14",
+				"dayjs": "^1.11.21",
+				"dompurify": "^3.3.3",
+				"es-toolkit": "^1.45.1",
+				"fastdom": "1.0.12",
+				"katex": "^0.16.47",
+				"khroma": "^2.1.0",
+				"marked": "^16.3.0",
+				"roughjs": "^4.6.6",
+				"stylis": "^4.3.6",
+				"ts-dedent": "^2.2.0",
+				"uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
+			}
 		},
 		"node_modules/minimalistic-assert": {
 			"version": "1.0.1",
@@ -2243,11 +3222,23 @@
 				}
 			}
 		},
+		"node_modules/package-manager-detector": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+			"integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+			"license": "MIT"
+		},
 		"node_modules/pako": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
 			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
 			"license": "(MIT AND Zlib)"
+		},
+		"node_modules/path-data-parser": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+			"integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+			"license": "MIT"
 		},
 		"node_modules/path-parse": {
 			"version": "1.0.7",
@@ -2293,6 +3284,22 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/points-on-curve": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+			"integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+			"license": "MIT"
+		},
+		"node_modules/points-on-path": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+			"integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+			"license": "MIT",
+			"dependencies": {
+				"path-data-parser": "0.1.0",
+				"points-on-curve": "0.2.0"
 			}
 		},
 		"node_modules/postcss": {
@@ -2399,6 +3406,12 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/robust-predicates": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+			"integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+			"license": "Unlicense"
+		},
 		"node_modules/rollup": {
 			"version": "4.60.1",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
@@ -2444,6 +3457,24 @@
 				"fsevents": "~2.3.2"
 			}
 		},
+		"node_modules/roughjs": {
+			"version": "4.6.6",
+			"resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+			"integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+			"license": "MIT",
+			"dependencies": {
+				"hachure-fill": "^0.5.2",
+				"path-data-parser": "^0.1.0",
+				"points-on-curve": "^0.2.0",
+				"points-on-path": "^0.2.1"
+			}
+		},
+		"node_modules/rw": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+			"integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+			"license": "BSD-3-Clause"
+		},
 		"node_modules/sade": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
@@ -2461,6 +3492,12 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"license": "MIT"
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"license": "MIT"
 		},
 		"node_modules/sax": {
@@ -2540,6 +3577,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/strictdom": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/strictdom/-/strictdom-1.0.1.tgz",
+			"integrity": "sha512-cEmp9QeXXRmjj/rVp9oyiqcvyocWab/HaoN4+bwFeZ7QzykJD6L3yD4v12K1x0tHpqRqVpJevN3gW7kyM39Bqg==",
+			"license": "MIT"
+		},
 		"node_modules/string_decoder": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -2548,6 +3591,12 @@
 			"dependencies": {
 				"safe-buffer": "~5.1.0"
 			}
+		},
+		"node_modules/stylis": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+			"integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+			"license": "MIT"
 		},
 		"node_modules/supports-preserve-symlinks-flag": {
 			"version": "1.0.0",
@@ -2635,7 +3684,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
 			"integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -2690,6 +3738,15 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/ts-dedent": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
+			"integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.10"
+			}
+		},
 		"node_modules/tslib": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -2727,6 +3784,19 @@
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
 			"license": "MIT"
+		},
+		"node_modules/uuid": {
+			"version": "14.0.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.2.tgz",
+			"integrity": "sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist-node/bin/uuid"
+			}
 		},
 		"node_modules/vite": {
 			"version": "7.3.6",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"jwt-decode": "^4.0.0",
 		"katex": "^0.16.45",
 		"markdown-it": "^14.1.1",
+		"mermaid": "^11.17.0",
 		"mongodb": "^7.1.1",
 		"ollama": "^0.6.3",
 		"openai": "^6.34.0",

--- a/src/lib/validation/parse-mermaid-request.ts
+++ b/src/lib/validation/parse-mermaid-request.ts
@@ -1,0 +1,31 @@
+import { HTTPError } from "../server/middleware/http-error"
+
+const MAX_DIAGRAM_CHARS = 10 * 1024 * 1024
+
+export type MermaidRequest = {
+	diagram: string
+	prompt: string
+}
+
+export const parseMermaidRequest = (input: unknown): MermaidRequest => {
+	if (!input || typeof input !== "object") {
+		throw new HTTPError(400, "Invalid request body")
+	}
+	const body = input as Record<string, unknown>
+
+	if (body.diagram !== undefined && typeof body.diagram !== "string") {
+		throw new HTTPError(400, "diagram must be a string")
+	}
+	const diagram = typeof body.diagram === "string" ? body.diagram : ""
+	if (diagram.length > MAX_DIAGRAM_CHARS) {
+		throw new HTTPError(400, "Diagram is too large")
+	}
+	if (typeof body.prompt !== "string" || body.prompt.trim() === "") {
+		throw new HTTPError(400, "prompt must be a non-empty string")
+	}
+
+	return {
+		diagram,
+		prompt: body.prompt
+	}
+}

--- a/src/routes/api/canvas/mermaid/+server.ts
+++ b/src/routes/api/canvas/mermaid/+server.ts
@@ -13,7 +13,41 @@ const MERMAID_VENDOR_ID = "OPENAI" as const
 const MERMAID_MODEL = "gpt-5.6-terra"
 
 const MERMAID_SYSTEM_PROMPT = `You are a Mermaid diagram generator. The user will give you the current Mermaid diagram source (may be empty) and a prompt describing what to create or change.
-Apply the requested changes and return ONLY valid Mermaid diagram syntax — no explanations, no preamble, no markdown code fences around the output.`
+Apply the requested changes and return ONLY valid Mermaid diagram syntax — no explanations, no preamble, no markdown code fences around the output.
+
+For well-known diagram types (flowchart, sequenceDiagram, classDiagram, stateDiagram-v2, erDiagram, gantt, pie, mindmap, journey, timeline) you already know the correct syntax.
+
+Some newer diagram types use stricter, less familiar keyword-based syntax. Do not improvise or guess syntax for these — use exactly this structure:
+
+venn-beta
+set A ["Kunder"]
+set B ["Abonnenter"]
+set C ["Nyhetsbrev"]
+union A,B ["Kunder med abonnement"]
+union A,C ["Kunder som mottar nyhetsbrev"]
+union B,C ["Abonnenter som mottar nyhetsbrev"]
+union A,B,C ["Kunder med abonnement og nyhetsbrev"]
+The overlap between two or more sets is always declared with the "union" keyword — never "intersection" or "overlap", even though the region it draws is the sets' intersection. "union" can list two or more set identifiers on one line.
+
+block-beta
+columns 1
+A
+B["Middle Block"]
+C
+A --> B
+B --> C
+
+packet-beta
+0-15: "Source Port"
+16-31: "Destination Port"
+32-47: "Length"
+
+architecture-beta
+service gateway(internet)[Gateway Label]
+service server(server)[App Server]
+gateway:B -- T:server
+
+If the user asks for a diagram type not listed above and you are not certain of its exact syntax, prefer a well-known diagram type that can reasonably represent the same information instead of guessing at unfamiliar syntax.`
 
 const mermaidHandler: ApiNextFunction = async ({ requestEvent, user }) => {
 	if (!APP_CONFIG.CANVAS_ENABLED) {

--- a/src/routes/api/canvas/mermaid/+server.ts
+++ b/src/routes/api/canvas/mermaid/+server.ts
@@ -1,0 +1,68 @@
+import { json, type RequestHandler } from "@sveltejs/kit"
+import { logger } from "@vestfoldfylke/loglady"
+import { canUseCanvas } from "$lib/authorization"
+import { getVendor } from "$lib/server/ai-vendors"
+import { APP_CONFIG } from "$lib/server/app-config/app-config"
+import { HTTPError } from "$lib/server/middleware/http-error"
+import { apiRequestMiddleware } from "$lib/server/middleware/http-request"
+import type { ApiNextFunction } from "$lib/types/middleware/http-request"
+import { parseMermaidRequest } from "$lib/validation/parse-mermaid-request"
+import { extractTextOutput } from "./extract-text-output"
+
+const MERMAID_VENDOR_ID = "OPENAI" as const
+const MERMAID_MODEL = "gpt-5.6-terra"
+
+const MERMAID_SYSTEM_PROMPT = `You are a Mermaid diagram generator. The user will give you the current Mermaid diagram source (may be empty) and a prompt describing what to create or change.
+Apply the requested changes and return ONLY valid Mermaid diagram syntax — no explanations, no preamble, no markdown code fences around the output.`
+
+const mermaidHandler: ApiNextFunction = async ({ requestEvent, user }) => {
+	if (!APP_CONFIG.CANVAS_ENABLED) {
+		throw new HTTPError(404, "Canvas is not enabled")
+	}
+	if (!canUseCanvas(user, APP_CONFIG.APP_ROLES)) {
+		throw new HTTPError(403, "Not authorized to use Canvas")
+	}
+	if (!APP_CONFIG.VENDORS.OPENAI.ENABLED) {
+		throw new HTTPError(503, "Diagram is not available — OpenAI vendor is not configured")
+	}
+
+	const body = await requestEvent.request.json()
+	const { diagram, prompt } = parseMermaidRequest(body)
+
+	logger.info("[Canvas Mermaid] User {userId} submitting prompt (diagramLength: {diagramLength})", user.userId, diagram.length)
+
+	const userMessage = diagram ? `Here is the current Mermaid diagram source:\n\n${diagram}\n\n---\n\nUser instruction: ${prompt}` : prompt
+
+	const vendor = getVendor(MERMAID_VENDOR_ID)
+	const response = await vendor.createChatResponse({
+		config: {
+			_id: "",
+			name: "Canvas Mermaid",
+			description: "",
+			vendorId: MERMAID_VENDOR_ID,
+			project: "DEFAULT",
+			model: MERMAID_MODEL,
+			accessGroups: ["all"],
+			type: "private",
+			created: { at: "", by: { id: "" } },
+			updated: { at: "", by: { id: "" } },
+			instructions: MERMAID_SYSTEM_PROMPT
+		},
+		inputs: [
+			{
+				type: "message.input",
+				role: "user",
+				content: [{ type: "input_text", text: userMessage }]
+			}
+		],
+		stream: false
+	})
+
+	const text = extractTextOutput(response.outputs)
+
+	return { isAuthorized: true, response: json({ diagram: text }) }
+}
+
+export const POST: RequestHandler = async (requestEvent) => {
+	return apiRequestMiddleware(requestEvent, mermaidHandler)
+}

--- a/src/routes/api/canvas/mermaid/+server.ts
+++ b/src/routes/api/canvas/mermaid/+server.ts
@@ -29,6 +29,8 @@ union B,C ["Abonnenter som mottar nyhetsbrev"]
 union A,B,C ["Kunder med abonnement og nyhetsbrev"]
 The overlap between two or more sets is always declared with the "union" keyword — never "intersection" or "overlap", even though the region it draws is the sets' intersection. "union" can list two or more set identifiers on one line.
 
+A venn-beta diagram must never have more than 3 sets. This is not a Mermaid restriction — it is a mathematical fact that circles cannot correctly represent all the overlaps among 4 or more sets (a 4th circle cannot intersect the other three in every way needed), so a 4-set Venn diagram is always visually broken regardless of how it is written. If the user asks for a Venn diagram with 4 or more categories, either merge the least important ones down to the 3 most important sets, or use a different diagram type (e.g. flowchart) that can clearly show 4+ categories and their relationships — whichever better preserves the user's intent. Never emit a venn-beta diagram with 4 or more "set" lines.
+
 block-beta
 columns 1
 A

--- a/src/routes/api/canvas/mermaid/+server.ts
+++ b/src/routes/api/canvas/mermaid/+server.ts
@@ -60,6 +60,10 @@ const mermaidHandler: ApiNextFunction = async ({ requestEvent, user }) => {
 
 	const text = extractTextOutput(response.outputs)
 
+	if (!text.trim()) {
+		throw new HTTPError(502, "Fikk ikke gyldig diagram fra modellen")
+	}
+
 	return { isAuthorized: true, response: json({ diagram: text }) }
 }
 

--- a/src/routes/api/canvas/mermaid/+server.ts
+++ b/src/routes/api/canvas/mermaid/+server.ts
@@ -29,6 +29,12 @@ union B,C ["Abonnenter som mottar nyhetsbrev"]
 union A,B,C ["Kunder med abonnement og nyhetsbrev"]
 The overlap between two or more sets is always declared with the "union" keyword — never "intersection" or "overlap", even though the region it draws is the sets' intersection. "union" can list two or more set identifiers on one line.
 
+To style a set or union's fill/border color, add a "style" line after the set/union declarations, e.g.:
+style A fill:#E8F4FD, stroke:#0072B1
+style B fill:#FDF0E8, stroke:#E06000
+style A,B fill:#F9F0FF, stroke:#7B2D8B
+A "style" line can target one set, or a comma-separated list of set identifiers to style their union region. If the user asks to color or style part of a Venn diagram, always add "style" lines like this — never silently ignore a styling request.
+
 A venn-beta diagram must never have more than 3 sets. This is not a Mermaid restriction — it is a mathematical fact that circles cannot correctly represent all the overlaps among 4 or more sets (a 4th circle cannot intersect the other three in every way needed), so a 4-set Venn diagram is always visually broken regardless of how it is written. If the user asks for a Venn diagram with 4 or more categories, either merge the least important ones down to the 3 most important sets, or use a different diagram type (e.g. flowchart) that can clearly show 4+ categories and their relationships — whichever better preserves the user's intent. Never emit a venn-beta diagram with 4 or more "set" lines.
 
 block-beta

--- a/src/routes/api/canvas/mermaid/extract-text-output.ts
+++ b/src/routes/api/canvas/mermaid/extract-text-output.ts
@@ -1,0 +1,17 @@
+import type { ChatOutputItem } from "$lib/types/chat-item"
+
+const UNSUPPORTED_OUTPUT_PREFIX = "Unsupported output item from OpenAI:"
+
+// gpt-5.6-terra is a reasoning model - OpenAI's Responses API returns a "reasoning" output item
+// alongside the real "message" one. The shared mapping (openai-mapping.ts) turns any non-message
+// output item into a placeholder output_text with this prefix rather than dropping it, so strip
+// it before treating the response as raw text. The document-editor endpoint never hits this path
+// since it streams instead of calling createChatResponse.
+export const extractTextOutput = (outputs: ChatOutputItem[]): string => {
+	return outputs
+		.flatMap((output) => output.content)
+		.filter((content) => content.type === "output_text")
+		.filter((content) => !content.text.startsWith(UNSUPPORTED_OUTPUT_PREFIX))
+		.map((content) => content.text)
+		.join("")
+}

--- a/src/routes/canvas/mermaid/+page.svelte
+++ b/src/routes/canvas/mermaid/+page.svelte
@@ -4,7 +4,7 @@
 	import PromptBar from "../PromptBar.svelte"
 	import { CANVAS_TOOLS, shouldShowToolTabs } from "../tools"
 
-	mermaid.initialize({ startOnLoad: false, theme: "neutral" })
+	mermaid.initialize({ startOnLoad: false, theme: "neutral", suppressErrorRendering: true })
 
 	let code = $state("")
 	let prompt = $state("")
@@ -42,7 +42,7 @@
 
 	$effect(() => {
 		const currentCode = code
-		if (!currentCode.trim()) {
+		if (isEditing || !currentCode.trim()) {
 			svg = ""
 			renderError = ""
 			return
@@ -93,6 +93,10 @@
 				a.click()
 				URL.revokeObjectURL(pngUrl)
 			}, "image/png")
+			URL.revokeObjectURL(svgUrl)
+		}
+		img.onerror = () => {
+			errorMessage = "Kunne ikke laste ned diagrammet som bilde"
 			URL.revokeObjectURL(svgUrl)
 		}
 		img.src = svgUrl

--- a/src/routes/canvas/mermaid/+page.svelte
+++ b/src/routes/canvas/mermaid/+page.svelte
@@ -1,0 +1,286 @@
+<script lang="ts">
+	import mermaid from "mermaid"
+	import { page } from "$app/state"
+	import PromptBar from "../PromptBar.svelte"
+	import { CANVAS_TOOLS, shouldShowToolTabs } from "../tools"
+
+	mermaid.initialize({ startOnLoad: false, theme: "neutral" })
+
+	let code = $state("")
+	let prompt = $state("")
+	let isLoading = $state(false)
+	let errorMessage = $state("")
+	let isEditing = $state(false)
+	let svg = $state("")
+	let renderError = $state("")
+
+	const submitPrompt = async () => {
+		if (!prompt.trim() || isLoading) return
+		isLoading = true
+		errorMessage = ""
+		const prevCode = code
+		try {
+			const res = await fetch("/api/canvas/mermaid", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ diagram: code, prompt })
+			})
+			if (!res.ok) {
+				const err = await res.json().catch(() => ({}))
+				throw new Error((err as { message?: string }).message ?? `HTTP ${res.status}`)
+			}
+			const data = (await res.json()) as { diagram: string }
+			code = data.diagram
+			prompt = ""
+		} catch (e) {
+			errorMessage = e instanceof Error ? e.message : "Ukjent feil"
+			code = prevCode
+		} finally {
+			isLoading = false
+		}
+	}
+
+	$effect(() => {
+		const currentCode = code
+		if (!currentCode.trim()) {
+			svg = ""
+			renderError = ""
+			return
+		}
+		let cancelled = false
+		const id = `mermaid-diagram-${Math.random().toString(36).slice(2)}`
+		mermaid
+			.render(id, currentCode)
+			.then((result) => {
+				if (!cancelled) {
+					svg = result.svg
+					renderError = ""
+				}
+			})
+			.catch((e: unknown) => {
+				if (!cancelled) {
+					renderError = e instanceof Error ? e.message : "Ugyldig diagram-syntaks"
+				}
+			})
+		return () => {
+			cancelled = true
+		}
+	})
+
+	const downloadImage = () => {
+		if (!svg) return
+		const svgBlob = new Blob([svg], { type: "image/svg+xml;charset=utf-8" })
+		const svgUrl = URL.createObjectURL(svgBlob)
+		const img = new Image()
+		img.onload = () => {
+			const scale = 2
+			const canvas = document.createElement("canvas")
+			canvas.width = img.width * scale
+			canvas.height = img.height * scale
+			const ctx = canvas.getContext("2d")
+			if (ctx) {
+				ctx.scale(scale, scale)
+				ctx.fillStyle = "white"
+				ctx.fillRect(0, 0, img.width, img.height)
+				ctx.drawImage(img, 0, 0)
+			}
+			canvas.toBlob((blob) => {
+				if (!blob) return
+				const pngUrl = URL.createObjectURL(blob)
+				const a = document.createElement("a")
+				a.href = pngUrl
+				a.download = "diagram.png"
+				a.click()
+				URL.revokeObjectURL(pngUrl)
+			}, "image/png")
+			URL.revokeObjectURL(svgUrl)
+		}
+		img.src = svgUrl
+	}
+</script>
+
+<div class="document-page">
+	<div class="canvas-topbar">
+		{#if shouldShowToolTabs(CANVAS_TOOLS)}
+			<nav class="canvas-tabs">
+				{#each CANVAS_TOOLS as tool (tool.id)}
+					<a class="canvas-tab" class:active={page.url.pathname.startsWith(tool.href)} href={tool.href}>
+						<span class="material-symbols-outlined">{tool.icon}</span>
+						{tool.label}
+					</a>
+				{/each}
+			</nav>
+		{/if}
+		<div class="topbar-actions">
+			<button onclick={() => (isEditing = !isEditing)} disabled={!code} title={isEditing ? "Forhåndsvis" : "Rediger kode"}>
+				<span class="material-symbols-outlined">{isEditing ? "preview" : "code"}</span>
+				{isEditing ? "Forhåndsvis" : "Rediger kode"}
+			</button>
+			<button onclick={downloadImage} disabled={!svg} title="Last ned som bilde">
+				<span class="material-symbols-outlined">download</span>
+				Last ned
+			</button>
+		</div>
+	</div>
+
+	<div class="canvas-body">
+		<div class="canvas-content">
+			<div class="canvas-paper">
+				{#if isEditing}
+					<textarea class="document-editor" bind:value={code} placeholder="mermaid diagramkode..."></textarea>
+				{:else if renderError}
+					<p class="empty-hint error-hint">Kunne ikke rendre diagrammet: {renderError}</p>
+				{:else if svg}
+					{@html svg}
+				{:else}
+					<p class="empty-hint">Ingen diagram enda. Skriv en instruksjon nedenfor for å komme i gang.</p>
+				{/if}
+			</div>
+		</div>
+	</div>
+
+	<div class="canvas-bottom">
+		{#if errorMessage}
+			<div class="error-banner">{errorMessage}</div>
+		{/if}
+		<PromptBar bind:value={prompt} placeholder="Beskriv hvilket diagram du vil lage…" {isLoading} sendDisabled={!prompt.trim()} onSubmit={submitPrompt} />
+	</div>
+</div>
+
+<style>
+	.document-page {
+		display: flex;
+		flex-direction: column;
+		flex: 1;
+		overflow: hidden;
+		min-height: 0;
+	}
+
+	.canvas-topbar {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+		padding: 0.5rem 1.5rem;
+		background-color: #f0f0ef;
+		border-bottom: 1px solid var(--color-primary-30);
+		flex-shrink: 0;
+	}
+
+	.canvas-tabs {
+		display: flex;
+		gap: 0.5rem;
+		overflow-x: auto;
+		white-space: nowrap;
+	}
+
+	.canvas-tab {
+		display: flex;
+		align-items: center;
+		gap: 0.25rem;
+		padding: 0.35rem 0.75rem;
+		border-radius: 14px;
+		color: var(--color-primary);
+		flex-shrink: 0;
+		text-decoration: none;
+	}
+
+	.canvas-tab.active {
+		background-color: var(--color-primary);
+		color: white;
+		font-weight: 700;
+	}
+
+	.topbar-actions {
+		display: flex;
+		align-items: center;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+	}
+
+	.canvas-body {
+		flex: 1;
+		overflow-y: auto;
+		padding: 2rem 1.5rem;
+		display: flex;
+		justify-content: center;
+	}
+
+	.canvas-content {
+		width: 100%;
+		max-width: 210mm;
+		align-self: flex-start;
+	}
+
+	.canvas-paper {
+		background: white;
+		border-radius: 2px;
+		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1), 0 0 0 1px rgba(0, 0, 0, 0.04);
+		padding: 25mm 20mm;
+		width: 100%;
+		min-height: 297mm;
+		box-sizing: border-box;
+		display: flex;
+		align-items: flex-start;
+		justify-content: center;
+	}
+
+	.empty-hint {
+		color: #aaa;
+		font-style: italic;
+	}
+
+	.error-hint {
+		color: var(--color-danger);
+	}
+
+	.document-editor {
+		width: 100%;
+		min-height: 247mm;
+		border: none;
+		outline: none;
+		resize: none;
+		font-family: monospace;
+		line-height: 1.6;
+		background: transparent;
+		box-sizing: border-box;
+	}
+
+	.canvas-bottom {
+		flex-shrink: 0;
+		width: 100%;
+		max-width: 210mm;
+		align-self: center;
+		padding: 0.75rem 1.5rem;
+		background-color: #f0f0ef;
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		box-sizing: border-box;
+	}
+
+	.error-banner {
+		padding: 0.4rem 0.75rem;
+		background-color: #fde8e8;
+		border-left: 3px solid #d32f2f;
+		border-radius: 4px;
+		font-size: small;
+		color: #b71c1c;
+	}
+
+	@media (max-width: 768px) {
+		.canvas-body {
+			padding: 1rem;
+		}
+
+		.canvas-paper {
+			padding: 1rem;
+			min-height: 40vh;
+		}
+
+		.document-editor {
+			min-height: 30vh;
+		}
+	}
+</style>

--- a/src/routes/canvas/tools.svelte.spec.ts
+++ b/src/routes/canvas/tools.svelte.spec.ts
@@ -19,7 +19,7 @@ describe("shouldShowToolTabs", () => {
 		expect(shouldShowToolTabs(tools)).toBe(true)
 	})
 
-	it("the real registry today has one tool, so the tab strip shows", () => {
+	it("the real registry today has two tools, so the tab strip shows", () => {
 		expect(shouldShowToolTabs(CANVAS_TOOLS)).toBe(true)
 	})
 })

--- a/src/routes/canvas/tools.ts
+++ b/src/routes/canvas/tools.ts
@@ -5,6 +5,9 @@ export type CanvasTool = {
 	href: string
 }
 
-export const CANVAS_TOOLS: CanvasTool[] = [{ id: "document", label: "Dokument", icon: "description", href: "/canvas/document" }]
+export const CANVAS_TOOLS: CanvasTool[] = [
+	{ id: "document", label: "Dokument", icon: "description", href: "/canvas/document" },
+	{ id: "mermaid", label: "Diagram", icon: "schema", href: "/canvas/mermaid" }
+]
 
 export const shouldShowToolTabs = (tools: CanvasTool[]): boolean => tools.length > 0

--- a/tests/server/canvas/mermaid/extract-text-output.test.ts
+++ b/tests/server/canvas/mermaid/extract-text-output.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+import type { ChatOutputItem } from "$lib/types/chat-item"
+import { extractTextOutput } from "../../../../src/routes/api/canvas/mermaid/extract-text-output"
+
+const messageOutput = (text: string): ChatOutputItem => ({
+	id: "1",
+	type: "message.output",
+	role: "assistant",
+	content: [{ type: "output_text", text }]
+})
+
+describe("extractTextOutput", () => {
+	it("returns the text from a single real message output", () => {
+		const outputs = [messageOutput("flowchart TD\n  A --> B")]
+		expect(extractTextOutput(outputs)).toBe("flowchart TD\n  A --> B")
+	})
+
+	it("strips a reasoning-model placeholder mixed in with the real output", () => {
+		const outputs = [messageOutput("Unsupported output item from OpenAI: reasoning"), messageOutput("flowchart TD\n  A --> B")]
+		expect(extractTextOutput(outputs)).toBe("flowchart TD\n  A --> B")
+	})
+
+	it("returns an empty string when only a placeholder is present", () => {
+		const outputs = [messageOutput("Unsupported output item from OpenAI: reasoning")]
+		expect(extractTextOutput(outputs)).toBe("")
+	})
+
+	it("joins text from multiple real message outputs in order", () => {
+		const outputs = [messageOutput("flowchart TD\n"), messageOutput("  A --> B")]
+		expect(extractTextOutput(outputs)).toBe("flowchart TD\n  A --> B")
+	})
+})

--- a/tests/server/canvas/mermaid/extract-text-output.test.ts
+++ b/tests/server/canvas/mermaid/extract-text-output.test.ts
@@ -29,4 +29,16 @@ describe("extractTextOutput", () => {
 		const outputs = [messageOutput("flowchart TD\n"), messageOutput("  A --> B")]
 		expect(extractTextOutput(outputs)).toBe("flowchart TD\n  A --> B")
 	})
+
+	it("returns an empty string when the model only produced a refusal (no output_text content)", () => {
+		const outputs: ChatOutputItem[] = [
+			{
+				id: "1",
+				type: "message.output",
+				role: "assistant",
+				content: [{ type: "output_refusal", reason: "content policy" }]
+			}
+		]
+		expect(extractTextOutput(outputs)).toBe("")
+	})
 })


### PR DESCRIPTION
## Summary
- Adds a new "Diagram" tool to Kladdeboka at `/canvas/mermaid`, alongside the existing document editor, using the shared shell/tab-strip/PromptBar built in the earlier Kladdeboka shell work.
- Prompt-driven Mermaid diagram generation (non-streaming AI call), with a raw-code edit toggle and PNG export.
- Promotes a hand-validated throwaway prototype into production code: real request validation (`parse-mermaid-request.ts`, mirroring the document tool's pattern), a tested pure function stripping a reasoning-model output placeholder that broke during prototyping, no prototype markers.
- Final whole-branch review caught and fixed two real bugs before merge: a DOM-node leak on failed diagram renders, and a silent-diagram-wipe on empty/refused model responses.
- Three follow-up fixes from manual QA, all in the system prompt: the model hallucinated syntax for newer Mermaid diagram types (venn/block/packet/architecture) since it has little training exposure to them — added concrete syntax examples; capped Venn diagrams at 3 sets since 4+ is a geometric impossibility with circles (falls back to a flowchart instead); taught the model venn-beta's `style` syntax after it was silently ignoring color requests.

## Test plan
- [x] `npm run test` passes (tsc, biome, build, vitest — 16/16 tests)
- [x] Auth-gate regression verified: Employee/Admin → 200, Student-only → 403, `CANVAS_ENABLED=false` → 404, across both the page and the API
- [x] Document tool (`/canvas/document`) confirmed unaffected
- [x] Manual QA in browser: editing, exports, tab strip, streaming all confirmed working
- [x] Venn diagram bugs (invalid syntax, 4+ set layout, ignored styling) found via manual QA and fixed, each re-verified against the live endpoint and mermaid's own parser
- [ ] Broader manual QA of block/packet/architecture diagram types (only Venn was exercised end-to-end so far)